### PR TITLE
feat: remove hard-coding of 'overwrite_if_exists=True' in create command

### DIFF
--- a/datakit_project/commands/create.py
+++ b/datakit_project/commands/create.py
@@ -2,6 +2,7 @@ import argparse
 from cliff.command import Command
 from cookiecutter.main import cookiecutter
 from cookiecutter.prompt import read_user_choice
+from cookiecutter.exceptions import OutputDirExistsException
 import cookiecutter.config as cc_config
 
 from .command_helpers import CommandHelpers
@@ -59,15 +60,18 @@ class Create(CommandHelpers, Command):
             template = self.get_template(parsed_args)
         if template:
             self.log.info("Creating project from template: {}".format(template))
-            cookiecutter(
-                template,
-                no_input=parsed_args.no_input
-            )
-            repo_dir = resolve_repo_dir(template)
-            # Update default template if it's empty or specifically requested
-            if self.default_template == '' or parsed_args.make_default:
-                self.update_configs({'default_template': repo_dir})
-                tmplt_msg = "Set default template to {} in plugin config ({})".format(repo_dir, self.plugin_config_path)
-                self.log.info(tmplt_msg)
+            try:
+                cookiecutter(
+                    template,
+                    no_input=parsed_args.no_input
+                )
+                repo_dir = resolve_repo_dir(template)
+                # Update default template if it's empty or specifically requested
+                if self.default_template == '' or parsed_args.make_default:
+                    self.update_configs({'default_template': repo_dir})
+                    tmplt_msg = "Set default template to {} in plugin config ({})".format(repo_dir, self.plugin_config_path)
+                    self.log.info(tmplt_msg)
+            except OutputDirExistsException:
+                self.log.info("Error: A project with the slug you provided already exists in this directory. Try again with a different slug.")
         else:
             self.log.info(NO_TEMPLATES_ERROR_WITH_HELP_MSG)

--- a/datakit_project/commands/create.py
+++ b/datakit_project/commands/create.py
@@ -61,7 +61,6 @@ class Create(CommandHelpers, Command):
             self.log.info("Creating project from template: {}".format(template))
             cookiecutter(
                 template,
-                overwrite_if_exists=True,
                 no_input=parsed_args.no_input
             )
             repo_dir = resolve_repo_dir(template)

--- a/datakit_project/commands/create.py
+++ b/datakit_project/commands/create.py
@@ -47,6 +47,13 @@ class Create(CommandHelpers, Command):
             default=False,
             help="Whether to allow user input for Cookiecutter execution"
         )
+        parser.add_argument(
+            '-o',
+            '--overwrite-if-exists',
+            action='store_true',
+            default=False,
+            help="Whether to overwrite a directory with the same name as project slug or exit gracefully"
+        )
         return parser
 
     def take_action(self, parsed_args):
@@ -63,7 +70,8 @@ class Create(CommandHelpers, Command):
             try:
                 cookiecutter(
                     template,
-                    no_input=parsed_args.no_input
+                    no_input=parsed_args.no_input,
+                    overwrite_if_exists=parsed_args.overwrite_if_exists
                 )
                 repo_dir = resolve_repo_dir(template)
                 # Update default template if it's empty or specifically requested

--- a/tests/commands/test_create.py
+++ b/tests/commands/test_create.py
@@ -70,6 +70,26 @@ def test_usage_of_default_template(monkeypatch, tmpdir):
 
 
 @pytest.mark.usefixtures('create_plugin_config_fake_repo')
+def test_usage_of_default_template(monkeypatch, tmpdir, caplog):
+    """
+    Create should exit gracefully and provide an appropriate
+    error message when user provides a slug with the same name
+    as an existing folder in the current working directory.
+    """
+    # Set up the configs to point default template at our fake repo
+    monkeypatch.chdir(tmpdir)
+    parsed_args = mock.Mock()
+    parsed_args.template = ''
+    parsed_args.make_default = False
+    parsed_args.interactive = False
+    cmd = Create(None, None, cmd_name='project create')
+    cmd.run(parsed_args)
+    cmd = Create(None, None, cmd_name='project create')
+    cmd.run(parsed_args)
+    assert 'Error: A project with the slug you provided already exists in this directory. Try again with a different slug.' in caplog.text
+
+
+@pytest.mark.usefixtures('create_plugin_config_fake_repo')
 def test_usage_of_nondefault_template(monkeypatch, tmpdir):
     """
     Create should support use of non-default template

--- a/tests/commands/test_create.py
+++ b/tests/commands/test_create.py
@@ -82,6 +82,7 @@ def test_graceful_handling_of_project_overwrite_attempt(monkeypatch, tmpdir, cap
     parsed_args.template = ''
     parsed_args.make_default = False
     parsed_args.interactive = False
+    parsed_args.overwrite_if_exists = False
     cmd = Create(None, None, cmd_name='project create')
     cmd.run(parsed_args)
     cmd.run(parsed_args)

--- a/tests/commands/test_create.py
+++ b/tests/commands/test_create.py
@@ -84,7 +84,6 @@ def test_usage_of_default_template(monkeypatch, tmpdir, caplog):
     parsed_args.interactive = False
     cmd = Create(None, None, cmd_name='project create')
     cmd.run(parsed_args)
-    cmd = Create(None, None, cmd_name='project create')
     cmd.run(parsed_args)
     assert 'Error: A project with the slug you provided already exists in this directory. Try again with a different slug.' in caplog.text
 

--- a/tests/commands/test_create.py
+++ b/tests/commands/test_create.py
@@ -70,7 +70,7 @@ def test_usage_of_default_template(monkeypatch, tmpdir):
 
 
 @pytest.mark.usefixtures('create_plugin_config_fake_repo')
-def test_usage_of_default_template(monkeypatch, tmpdir, caplog):
+def test_graceful_handling_of_project_overwrite_attempt(monkeypatch, tmpdir, caplog):
     """
     Create should exit gracefully and provide an appropriate
     error message when user provides a slug with the same name


### PR DESCRIPTION
At The Post, we're hoping to safeguard against the possibility that an existing directory with the same name as a new datakit project is overwritten when `create` is run in the parent directory.

I noticed the default of `overwrite_if_exists=True` in this repo, and I believe removing this will address our issue.

However, after I forked the repo, I noticed multiple test failures (10 of the 20 tests fail). I verified the test failures are the same with and without the code changes in this PR, but I wanted to run it by you since you're more familiar with the code. Are there setup steps or something that I'm missing when it comes to running the tests with `pytest`?

Output below:
```
====================================================================================== short test summary info ======================================================================================
FAILED tests/commands/test_create.py::test_warning_when_no_default_repo_setting - AssertionError: assert 'No project templates have been installed' in ''
FAILED tests/commands/test_create.py::test_create_initial_project - assert False
FAILED tests/commands/test_create.py::test_new_default_template - assert False
FAILED tests/commands/test_create_autogen_plugins_dir.py::test_missing_config_file - AssertionError: assert 'No project templates have been installed' in ''
FAILED tests/commands/test_create_interactive.py::test_interactive_project_selection - AssertionError: assert 'Creating project from template: fake-repo' in ''
FAILED tests/commands/test_templates.py::test_no_templates - AssertionError: assert '/private/var/folders/3s/f7yml0ln08j3z7dnzwyr48p00000gq/T/pytest-of-foremanh/pytest-1/test_no_templates0/.cook...
FAILED tests/commands/test_templates.py::test_multiple_templates - AssertionError: assert 'Name            SHA       Date         Subject' in ['']
FAILED tests/commands/test_templates_status.py::test_noupdate_status - AssertionError: assert 'Name            SHA       Date         Upstream SHA   Upstream Date   Commits behind' in ['']
FAILED tests/commands/test_templates_status.py::test_repo_behind_upstream - AssertionError: assert 'Name            SHA       Date         Upstream SHA   Upstream Date   Commits behind' in ['']
FAILED tests/commands/test_templates_update.py::test_nothing_to_update - AssertionError: assert 'Local templates are all up-to-date' in ''
=================================================================================== 10 failed, 10 passed in 0.52s ===================================================================================
```

Thank you for the help with this!